### PR TITLE
Show expected Docker compose output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are an experienced GX user, these tutorials will provide code examples of
 > [!IMPORTANT]
 > The first time that you start the Docker compose instance, the underlying Docker images need to be built. This process can take several minutes.
 >
-> When environment is ready, you will see the following output in the terminal:
+> **When environment is ready, you will see the following output in the terminal:**
 >
 >```
 >✔ Network tutorial-gx-in-the-data-pipeline_gxnet         Created

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ If you are an experienced GX user, these tutorials will provide code examples of
    ```
 
 > [!NOTE]
-> The first time that you start the Docker compose instance, the underlying Docker images need to be built. This process can take several minutes.
+> The first time that you start the Docker compose instance, the underlying Docker images need to be built. This process can take several minutes. When environment is ready, you will see the following output in the terminal:
+>
+>```
+>✔ Network tutorial-gx-in-the-data-pipeline_gxnet         Created
+>✔ Container tutorial-gx-in-the-data-pipeline-postgres    Healthy
+>✔ Container tutorial-gx-in-the-data-pipeline-airflow     Healthy
+>✔ Container tutorial-gx-in-the-data-pipeline-jupyterlab  Healthy
+>```
 
 4. Access the JupyterLab (to run tutorial cookbooks) and Airflow (to run data pipelines) applications using a web browser.
    * JupyterLab: `http://localhost:8888/lab`

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ If you are an experienced GX user, these tutorials will provide code examples of
    docker compose up --build --detach --wait
    ```
 
-> [!NOTE]
-> The first time that you start the Docker compose instance, the underlying Docker images need to be built. This process can take several minutes. When environment is ready, you will see the following output in the terminal:
+> [!IMPORTANT]
+> The first time that you start the Docker compose instance, the underlying Docker images need to be built. This process can take several minutes.
+>
+> When environment is ready, you will see the following output in the terminal:
 >
 >```
 >✔ Network tutorial-gx-in-the-data-pipeline_gxnet         Created


### PR DESCRIPTION
Addressing review feedback that arrived post-PR: include the expected terminal output of Docker compose in the README. 

Check out the rendered README here: https://github.com/greatexpectationslabs/tutorial-gx-in-the-data-pipeline/tree/show-docker-compose-output?tab=readme-ov-file#quickstart